### PR TITLE
replace np.bool with bool 

### DIFF
--- a/pyperm/classes.py
+++ b/pyperm/classes.py
@@ -48,7 +48,7 @@ class Field:
         masksize = mask.shape
 
         # Check that the mask is a boolean array
-        if mask.dtype != np.bool:
+        if mask.dtype != bool:
             raise Exception("The mask must be a boolean array")
 
         # Assign the dimension

--- a/pyperm/classes.py
+++ b/pyperm/classes.py
@@ -137,7 +137,7 @@ class Field:
             raise ValueError("The size of the mask must be compatible with the field")
         elif (self.D == 1) and tuple(np.sort(value.shape)) != self.masksize:
             raise ValueError("The size of the mask must be compatible with the field")
-        if  value.dtype != np.bool:
+        if  value.dtype != bool:
             raise Exception("The mask must be a boolean array")
         self.__mask = value
         self.masksize = value.shape


### PR DESCRIPTION
In [NumPy 1.20.0 Release Notes](https://github.com/numpy/numpy/releases/tag/v1.20.0): using the aliases of builtin types like np.bool  was deprecated.


In [NumPy 1.24.0](https://github.com/numpy/numpy/releases/tag/v1.24.0): the deprecated np.bool was entirely removed.