### PR TITLE
fix requirements install of 'scikit-learn' and 'statsmodels'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'scikit-learn',
         'scipy',
         'scikit-image',
+        'statsmodels',
         'nilearn'
     ],
     version = '0.0.3',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'numpy',
         'sanssouci',
         'matplotlib',
-        'sklearn',
+        'scikit-learn',
         'scipy',
         'scikit-image',
         'nilearn'


### PR DESCRIPTION
The PyPI package 'sklearn' is deprecated. Changing to 'scikit-learn' fixed the install issues on my end. 

Also 'statsmodels' was needed to `import pyperm as pr`.